### PR TITLE
added support for typescript 2.3

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -222,6 +222,8 @@ const typeScriptVersionLineParser: pm.Parser<TypeScriptVersion> =
 				return pm.succeed<TypeScriptVersion>("2.1");
 			case "2":
 				return pm.succeed<TypeScriptVersion>("2.2");
+			case "3":
+				return pm.succeed<TypeScriptVersion>("2.3");
 			default:
 				return pm.fail(`TypeScript 2.${d} is not yet supported.`);
 		}

--- a/test/test.ts
+++ b/test/test.ts
@@ -57,6 +57,11 @@ describe("parseTypeScriptVersionLine", () => {
 		const wrong = "// TypeScript Version: 3.14";
 		assert.throws(() => parseTypeScriptVersionLine(wrong));
 	});
+
+	it("allows typescript 2.3", () => {
+		const src = "// TypeScript Version: 2.3";
+		assert.equal(parseTypeScriptVersionLine(src), "2.3");
+	});
 });
 
 function dedent(strings: TemplateStringsArray) {


### PR DESCRIPTION
I want to publish typings that require typescript 2.3, however the travis test fails because 2.3 is not yet supported (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/16809#issuecomment-304638042).

According to https://github.com/Microsoft/dtslint/issues/31#issuecomment-298365119 it should be however. This fix should enable typescript 2.3 support.