### PR TITLE
Support TypeScript 2.8 in the header language version parser

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="parsimmon" />
 import pm = require("parsimmon");
 /** Parse-able TypeScript versions. Only add to this list if we will support this version on DefinitelyTyped. */
-export declare type TypeScriptVersion = "2.0" | "2.1" | "2.2" | "2.3" | "2.4" | "2.5" | "2.6" | "2.7";
+export declare type TypeScriptVersion = "2.0" | "2.1" | "2.2" | "2.3" | "2.4" | "2.5" | "2.6" | "2.7" | "2.8";
 export declare namespace TypeScriptVersion {
     const all: ReadonlyArray<TypeScriptVersion>;
     const lowest: TypeScriptVersion;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const pm = require("parsimmon");
 var TypeScriptVersion;
 (function (TypeScriptVersion) {
-    TypeScriptVersion.all = ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"];
+    TypeScriptVersion.all = ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8"];
     TypeScriptVersion.lowest = TypeScriptVersion.all[0];
     /** Latest version that may be specified in a `// TypeScript Version:` header. */
     TypeScriptVersion.latest = TypeScriptVersion.all[TypeScriptVersion.all.length - 1];

--- a/index.ts
+++ b/index.ts
@@ -10,9 +10,9 @@ Example:
 */
 
 /** Parse-able TypeScript versions. Only add to this list if we will support this version on DefinitelyTyped. */
-export type TypeScriptVersion = "2.0" | "2.1" | "2.2" | "2.3" | "2.4" | "2.5" | "2.6" | "2.7";
+export type TypeScriptVersion = "2.0" | "2.1" | "2.2" | "2.3" | "2.4" | "2.5" | "2.6" | "2.7" | "2.8";
 export namespace TypeScriptVersion {
-	export const all: ReadonlyArray<TypeScriptVersion> = ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"];
+	export const all: ReadonlyArray<TypeScriptVersion> = ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8"];
 	export const lowest = all[0];
 	/** Latest version that may be specified in a `// TypeScript Version:` header. */
 	export const latest = all[all.length - 1];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1025,9 +1025,9 @@
       }
     },
     "typescript": {
-      "version": "2.8.0-dev.20180318",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.0-dev.20180318.tgz",
-      "integrity": "sha512-3yf65OziJSNJhL5PYUqLNr1Bm7wwZA6HJ/hcMiu1o33MIZiTTWKCy2IzE9932KQYqmbPLZxPT4RS/0Q5DBJnWA==",
+      "version": "2.9.0-dev.20180402",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.0-dev.20180402.tgz",
+      "integrity": "sha512-3KesGmXK/niHKaJUAHrZTmJ/fLEAgCtG6bWo05VF+b9WLoy+FMNYxuC4bQyaJf0WLydlKHR8RIjE8Z2rK+6Q8Q==",
       "dev": true
     },
     "v8flags": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "index.d.ts",
     "index.js"
   ],
+  "repository": "https://github.com/Microsoft/definitelytyped-header-parser",
   "scripts": {
     "all": "npm-run-all build lint test",
     "build": "tsc",


### PR DESCRIPTION
1. I wanted to update a project I use [`type-zoo`](https://github.com/pelotom/type-zoo) to use TypeScript language features introduced in TypeScript 2.8.
2. This project depends on  [`dtslint`](https://github.com/Microsoft/dtslint) for validating TypeScript Versions
3. Selecting `// TypeScript Version 2.8` causes `dtslint` to fail, which forced me to figure out how `dtslint` finds language versions, which pointed me to this repo. 

- This also fixes a warning in the npm install output.
- This also updates the `package-lock.json` file as TypeScript has a new `next` version now.