### PR TITLE
Fix parsing bug for TS versions >= 3

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -258,7 +258,7 @@ function parseLabel(strict: boolean): pm.Parser<Label> {
 }
 
 const typeScriptVersionLineParser: pm.Parser<TypeScriptVersion> =
-	pm.regexp(/\/\/ TypeScript Version: (2.(\d))/, 1).chain<TypeScriptVersion>(v =>
+	pm.regexp(/\/\/ TypeScript Version: (\d.(\d))/, 1).chain<TypeScriptVersion>(v =>
 		TypeScriptVersion.all.includes(v as TypeScriptVersion)
 			? pm.succeed(v as TypeScriptVersion)
 			: pm.fail(`TypeScript ${v} is not yet supported.`));

--- a/test/test.ts
+++ b/test/test.ts
@@ -73,6 +73,16 @@ describe("parseTypeScriptVersionLine", () => {
 		const src = "// TypeScript Version: 2.3";
 		assert.equal(parseTypeScriptVersionLine(src), "2.3");
 	});
+	
+	it("allows post 3 version tags", () => {
+		const src = "// TypeScript Version: 3.0";
+		assert.equal(parseTypeScriptVersionLine(src), "3.0")
+	})
+
+	it("does not allow unallowed version tags", () => {
+		const src = "// TypeScript Version: 3.7";
+		assert.throws(() => parseTypeScriptVersionLine(src), `Could not parse version: line is ${src}`);
+	})
 });
 
 describe("tagsToUpdate", () => {


### PR DESCRIPTION
#15 was closed because [`fef4df5`](https://github.com/Microsoft/definitelytyped-header-parser/commit/fef4df579aec54772cc5e0bbac071cff21e57a4c) added tags `3.0` and `3.1`, and it was said that resolved issues with `3.x` in this [comment](https://github.com/Microsoft/definitelytyped-header-parser/commit/fef4df579aec54772cc5e0bbac071cff21e57a4c#issuecomment-432427788).

However, the value 2 was hardcoded into the regex in `parseTypeScriptVersionLine`, and so even with these tags, it still can't parse `// TypeScript Version: 3.0`.

This PR resolves that, while still maintaining that unapproved tags cannot be parsed.

This would also solve downstream problems in [dtslint](https://github.com/Microsoft/dtslint/issues/137).