### PR TITLE
Add 'non-npm package' marker on Type Definitions line.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -69,6 +69,7 @@ export namespace TypeScriptVersion {
 }
 
 export interface Header {
+	readonly nonNpm: boolean;
 	readonly libraryName: string;
 	readonly libraryMajorVersion: number;
 	readonly libraryMinorVersion: number;
@@ -140,7 +141,7 @@ function parseHeader(text: string, strict: boolean): Header | ParseError {
 
 function headerParser(strict: boolean): pm.Parser<Header> {
 	return pm.seqMap(
-		pm.string("// Type definitions for "),
+		pm.regex(/\/\/ Type definitions for (non-npm package )?/),
 		parseLabel(strict),
 		pm.string("// Project: "),
 		projectParser,
@@ -150,10 +151,11 @@ function headerParser(strict: boolean): pm.Parser<Header> {
 		typeScriptVersionParser,
 		pm.all, // Don't care about the rest of the file
 		// tslint:disable-next-line:variable-name
-		(_str, label, _project, projects, _defsBy, contributors, _definitions, typeScriptVersion) => ({
+		(str, label, _project, projects, _defsBy, contributors, _definitions, typeScriptVersion) => ({
 			libraryName: label.name,
 			libraryMajorVersion: label.major,
 			libraryMinorVersion: label.minor,
+			nonNpm: str.endsWith("non-npm package "),
 			projects, contributors, typeScriptVersion,
 		}));
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -16,6 +16,7 @@ describe("parse", () => {
 			libraryMajorVersion: 1,
 			libraryMinorVersion: 2,
 			typeScriptVersion: "2.2",
+			nonNpm: false,
 			projects: ["https://github.com/foo/foo", "https://foo.com"],
 			contributors: [
 				{ name: "My Self", url: "https://github.com/me", githubUsername: "me" },
@@ -40,6 +41,7 @@ describe("parse", () => {
 			libraryMajorVersion: 1,
 			libraryMinorVersion: 2,
 			typeScriptVersion: "2.0",
+			nonNpm: false,
 			projects: ["https://github.com/foo/foo", "https://foo.com"],
 			contributors: [
 				{ name: "My Self", url: "https://github.com/me", githubUsername: "me" },
@@ -57,6 +59,19 @@ describe("parse", () => {
 		assert.deepStrictEqual(parseHeaderOrFail(src).contributors, [
 			{ name: "Bad Url", url: "sptth://hubgit.moc/em", githubUsername: undefined },
 		]);
+	});
+
+	it("allows 'non-npm' on Type definitions line", () => {
+		const src = dedent`
+			// Type definitions for non-npm package foo 1.2
+			// Project: https://github.com/foo/foo, https://foo.com
+			// Definitions by: My Self <https://github.com/me>, Some Other Guy <https://github.com/otherguy>
+			// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+			// TypeScript Version: 2.2
+
+			...file content...`;
+		console.log(parseHeaderOrFail(src))
+			assert.equal(parseHeaderOrFail(src).nonNpm, true);
 	});
 });
 
@@ -80,7 +95,7 @@ describe("parseTypeScriptVersionLine", () => {
 	})
 
 	it("does not allow unallowed version tags", () => {
-		const src = "// TypeScript Version: 3.7";
+		const src = "// TypeScript Version: 4.7";
 		assert.throws(() => parseTypeScriptVersionLine(src), `Could not parse version: line is ${src}`);
 	})
 });
@@ -89,7 +104,7 @@ describe("tagsToUpdate", () => {
 	it("works", () => {
 		assert.deepEqual(
 			TypeScriptVersion.tagsToUpdate("2.5"),
-			["ts2.5", "ts2.6", "ts2.7", "ts2.8", "ts2.9", "ts3.0", "ts3.1", "ts3.2", "latest"]);
+			["ts2.5", "ts2.6", "ts2.7", "ts2.8", "ts2.9", "ts3.0", "ts3.1", "ts3.2", "ts3.3", "ts3.4", "latest"]);
 	});
 });
 


### PR DESCRIPTION
This allows people to mark their packages as not on npm. This will allow tools like dts-critic to treat these packages differently.

If we decide to ship this change, I'll update Definitely Typed after it merges.

Specifically, the first line can now have two possible headers:

```
// Type definitions for x
```

or 

```
// Type definitions for non-npm package x
```