### PR TITLE
fix: compatible  for contributor urls which end with slash

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -198,14 +198,15 @@ function contributorsParser(strict: boolean): pm.Parser<ReadonlyArray<Author>> {
     const contributor: pm.Parser<Author> = strict
         ? pm.seqMap(
             pm.regexp(/([^<]+) /, 1),
-            pm.regexp(/\<https\:\/\/github\.com\/([a-zA-Z\d\-]+)\>/, 1),
+            pm.regexp(/\<https\:\/\/github\.com\/([a-zA-Z\d\-]+)\/?\>/, 1),
             (name, githubUsername) => ({ name, url: `https://github.com/${githubUsername}`, githubUsername }))
         // In non-strict mode, allows arbitrary URL, and trailing whitespace.
         : pm.seqMap(pm.regexp(/([^<]+) /, 1), pm.regexp(/<([^>]+)> */, 1), (name, url) => {
-            const rgx = /^https\:\/\/github.com\/([a-zA-Z\d\-]+)$/;
+            const rgx = /^https\:\/\/github.com\/([a-zA-Z\d\-]+)\/?$/;
             const match = rgx.exec(url);
+            const githubUsername = match === null ? undefined : match[1];
             // tslint:disable-next-line no-null-keyword
-            return ({ name, url, githubUsername: match === null ? undefined : match[1] });
+            return ({ name, url: githubUsername ? `https://github.com/${githubUsername}` : url, githubUsername });
         });
     return pm.sepBy1(contributor, separator);
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -50,6 +50,31 @@ describe("parse", () => {
         });
     });
 
+    it("works with slash end", () => {
+        const src = dedent`
+            // Type definitions for foo 1.2
+            // Project: https://github.com/foo/foo,
+            //          https://foo.com
+            // Definitions by: My Self <https://github.com/me/>,
+            //                 Some Other Guy <https://github.com/otherguy/>
+            // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+            ...file content...`;
+
+        assert.deepStrictEqual(parseHeaderOrFail(src), {
+            libraryName: "foo",
+            libraryMajorVersion: 1,
+            libraryMinorVersion: 2,
+            typeScriptVersion: "2.8",
+            nonNpm: false,
+            projects: ["https://github.com/foo/foo", "https://foo.com"],
+            contributors: [
+                { name: "My Self", url: "https://github.com/me", githubUsername: "me" },
+                { name: "Some Other Guy", url: "https://github.com/otherguy", githubUsername: "otherguy" },
+            ],
+        });
+    });
+
     it("works with bad url", () => {
         const src = dedent`
             // Type definitions for foo 1.2


### PR DESCRIPTION
before only support `https://github.com/me`,
now support ends with slash like `https://github.com/me/`

check out [this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42860) for `DefinitelyTyped`.

The first contrtibutor plantain-00 doesn't be got by CI scripts.

```ts
// Type definitions for markdown-it v10.0.0
// Project: https://github.com/markdown-it/markdown-it
// Definitions by: York Yao <https://github.com/plantain-00/>
//                 Robert Coie <https://github.com/rapropos>
//                 duduluu <https://github.com/duduluu>
// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
// TypeScript Version: 2.0

import MarkdownIt = require('./lib');

export = MarkdownIt;
```